### PR TITLE
feat: add normalize date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { default as normalizeMoney } from './normalizers/normalizeMoney';
 export { default as normalizeCpfOrCnpj } from './normalizers/normalizeCpfOrCnpj';
 export { default as normalizePhone } from './normalizers/normalizePhone';
 export { default as normalizePis } from './normalizers/normalizePis';
+export { default as normalizeDate } from './normalizers/normalizeDate';
 
 // utils
 export { default as maskString } from './utils/maskString';

--- a/src/normalizers/normalizeDate.ts
+++ b/src/normalizers/normalizeDate.ts
@@ -1,36 +1,39 @@
 type Types = 'bigger' | 'long' | 'numeric';
 
 export default function normalizeDate(date: string, type: Types = 'numeric') {
-  const bigger = () => new Date(`${date}Z`).toLocaleString('pt-BR', {
-    weekday: 'long',
-    month: 'long',
-    year: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    timeZone: 'America/Sao_Paulo',
-    timeZoneName: 'long'
-  })
-    
-  const long = () => new Date(date).toLocaleDateString('pt-BR', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
+  const bigger = () =>
+    new Date(`${date}Z`).toLocaleString('pt-BR', {
+      weekday: 'long',
+      month: 'long',
+      year: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      timeZone: 'America/Sao_Paulo',
+      timeZoneName: 'long',
+    });
 
-  const numeric = () => new Date(date).toLocaleDateString('pt-BR', {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric'
-  })
+  const long = () =>
+    new Date(date).toLocaleDateString('pt-BR', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+  const numeric = () =>
+    new Date(date).toLocaleDateString('pt-BR', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
 
   const func: any = {
     bigger,
     long,
-    numeric
-  }
+    numeric,
+  };
 
   return func[type]();
 }

--- a/src/normalizers/normalizeDate.ts
+++ b/src/normalizers/normalizeDate.ts
@@ -1,0 +1,36 @@
+type Types = 'bigger' | 'long' | 'numeric';
+
+export default function normalizeDate(date: string, type: Types = 'numeric') {
+    const bigger = new Date(`${date}Z`).toLocaleString('pt-BR', {
+        weekday: 'long',
+        month: 'long',
+        year: 'numeric',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
+        timeZone: 'America/Sao_Paulo',
+        timeZoneName: 'long'
+    })
+    
+    const long  = new Date(date).toLocaleDateString('pt-BR', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    })
+
+    const numeric  = new Date(date).toLocaleDateString('pt-BR', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric'
+    })
+
+    const func: any = {
+        bigger,
+        long,
+        numeric
+    }
+
+    return func[type];
+}

--- a/src/normalizers/normalizeDate.ts
+++ b/src/normalizers/normalizeDate.ts
@@ -1,36 +1,36 @@
 type Types = 'bigger' | 'long' | 'numeric';
 
 export default function normalizeDate(date: string, type: Types = 'numeric') {
-    const bigger = new Date(`${date}Z`).toLocaleString('pt-BR', {
-        weekday: 'long',
-        month: 'long',
-        year: 'numeric',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
-        timeZone: 'America/Sao_Paulo',
-        timeZoneName: 'long'
-    })
+  const bigger = () => new Date(`${date}Z`).toLocaleString('pt-BR', {
+    weekday: 'long',
+    month: 'long',
+    year: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    timeZone: 'America/Sao_Paulo',
+    timeZoneName: 'long'
+  })
     
-    const long  = new Date(date).toLocaleDateString('pt-BR', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-    })
+  const long = () => new Date(date).toLocaleDateString('pt-BR', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
 
-    const numeric  = new Date(date).toLocaleDateString('pt-BR', {
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric'
-    })
+  const numeric = () => new Date(date).toLocaleDateString('pt-BR', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric'
+  })
 
-    const func: any = {
-        bigger,
-        long,
-        numeric
-    }
+  const func: any = {
+    bigger,
+    long,
+    numeric
+  }
 
-    return func[type];
+  return func[type]();
 }

--- a/tests/normalizeDate.spec.ts
+++ b/tests/normalizeDate.spec.ts
@@ -4,19 +4,23 @@ import { normalizeDate } from '../src';
 
 describe('test normalizeDate', () => {
   test('spec normalize date types', () => {
-    expect(normalizeDate('2023-12-12 23:39:25.756', 'bigger'))
-      .toBe('terça-feira, 12 de dezembro de 2023 20:39:25 Horário Padrão de Brasília');
-    
-    expect(normalizeDate('2023-01-01 23:39:25.756', 'long'))
-        .toBe('domingo, 1 de janeiro de 2023');
-    
-    expect(normalizeDate('2023-01-16 23:39:25.756'))
-      .toBe('16/01/2023');
-    
-    expect(normalizeDate('2023-22-12 23:39:25.756', 'long'))
-      .toBe('Invalid Date');
+    expect(normalizeDate('2023-12-12 23:39:25.756', 'bigger')).toBe(
+      'terça-feira, 12 de dezembro de 2023 20:39:25 Horário Padrão de Brasília',
+    );
 
-    expect(normalizeDate('2023-01-01 23:39:25.756'))
-      .not.toBe('domingo, 1 de janeiro de 2023');
+    expect(normalizeDate('2023-01-01 23:39:25.756', 'long')).toBe(
+      'domingo, 1 de janeiro de 2023',
+    );
+
+    expect(normalizeDate('2023-01-16 23:39:25.756')).toBe('16/01/2023');
+
+    expect(normalizeDate('2023-22-12 23:39:25.756', 'long')).toBe(
+      'Invalid Date',
+    );
+
+    expect(normalizeDate('2023-01-01 23:39:25.756')).not.toBe(
+      'domingo, 1 de janeiro de 2023',
+    );
   });
 });
+

--- a/tests/normalizeDate.spec.ts
+++ b/tests/normalizeDate.spec.ts
@@ -1,0 +1,22 @@
+import 'jest';
+
+import { normalizeDate } from '../src';
+
+describe('test normalizeDate', () => {
+  test('spec normalize date types', () => {
+    expect(normalizeDate('2023-12-12 23:39:25.756', 'bigger'))
+      .toBe('terça-feira, 12 de dezembro de 2023 20:39:25 Horário Padrão de Brasília');
+    
+    expect(normalizeDate('2023-01-01 23:39:25.756', 'long'))
+        .toBe('domingo, 1 de janeiro de 2023');
+    
+    expect(normalizeDate('2023-01-16 23:39:25.756'))
+      .toBe('16/01/2023');
+    
+    expect(normalizeDate('2023-22-12 23:39:25.756', 'long'))
+      .toBe('Invalid Date');
+
+    expect(normalizeDate('2023-01-01 23:39:25.756'))
+      .not.toBe('domingo, 1 de janeiro de 2023');
+  });
+});


### PR DESCRIPTION
# Description

Add normalize date

`normalizeDate(date, type)`

types outputs:
`numeric | default:` 16/01/2023
`long:` domingo, 1 de janeiro de 2023
`bigger:` terça-feira, 12 de dezembro de 2023 20:39:25 Horário Padrão de Brasília

## Type of change

<!-- Check all relevant options. -->

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

- [x] Read the [Contributing Guide](https://github.com/pagnet/blu-utils/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
