### PR TITLE
bug-fix: normalize date function

### DIFF
--- a/src/normalizers/normalizeDate.ts
+++ b/src/normalizers/normalizeDate.ts
@@ -26,7 +26,6 @@ export default function normalizeDate(date: string, type: DateTypes = 'numeric')
     },
   };
 
-
   const dateFormatted = (): Date => {
     const d = new Date(date);
     const tzOffset = d.getTimezoneOffset();

--- a/src/normalizers/normalizeDate.ts
+++ b/src/normalizers/normalizeDate.ts
@@ -1,8 +1,8 @@
-type Types = 'bigger' | 'long' | 'numeric';
+type DateTypes = 'bigger' | 'long' | 'numeric';
 
-export default function normalizeDate(date: string, type: Types = 'numeric') {
-  const bigger = () =>
-    new Date(`${date}Z`).toLocaleString('pt-BR', {
+export default function normalizeDate(date: string, type: DateTypes = 'numeric'): string {
+  const options: Record<DateTypes, object> = {
+    bigger: {
       weekday: 'long',
       month: 'long',
       year: 'numeric',
@@ -12,28 +12,30 @@ export default function normalizeDate(date: string, type: Types = 'numeric') {
       second: 'numeric',
       timeZone: 'America/Sao_Paulo',
       timeZoneName: 'long',
-    });
-
-  const long = () =>
-    new Date(date).toLocaleDateString('pt-BR', {
+    },
+    long: {
       weekday: 'long',
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-    });
-
-  const numeric = () =>
-    new Date(date).toLocaleDateString('pt-BR', {
+    },
+    numeric: {
       year: 'numeric',
       month: 'numeric',
       day: 'numeric',
-    });
-
-  const func: any = {
-    bigger,
-    long,
-    numeric,
+    },
   };
 
-  return func[type]();
+  const dateFormatted = (): Date => {
+    const d = new Date(date);
+    const tzOffset = d.getTimezoneOffset();
+    d.setTime(d.getTime() + tzOffset * 60 * 1000);
+    return d;
+  };
+
+  const formatter = dateFormatted().toLocaleDateString('pt-BR', options[type]);
+
+  return formatter;
 }
+
+console.log(normalizeDate('2023-05-31'))

--- a/src/normalizers/normalizeDate.ts
+++ b/src/normalizers/normalizeDate.ts
@@ -37,5 +37,3 @@ export default function normalizeDate(date: string, type: DateTypes = 'numeric')
 
   return formatter;
 }
-
-console.log(normalizeDate('2023-05-31'))

--- a/tests/normalizeDate.spec.ts
+++ b/tests/normalizeDate.spec.ts
@@ -1,26 +1,46 @@
 import 'jest';
+import { normalizeDate } from '../src/';
 
-import { normalizeDate } from '../src';
-
-describe('test normalizeDate', () => {
-  test('spec normalize date types', () => {
-    expect(normalizeDate('2023-12-12 23:39:25.756', 'bigger')).toBe(
-      'terça-feira, 12 de dezembro de 2023 20:39:25 Horário Padrão de Brasília',
+describe('normalizeDate', () => {
+  test('should return the expected formatted date for type "bigger"', () => {
+    const result = normalizeDate('2023-12-12 23:39:25.756Z', 'bigger');
+    expect(result).toBe(
+      'terça-feira, 12 de dezembro de 2023 23:39:25 Horário Padrão de Brasília',
     );
-
-    expect(normalizeDate('2023-01-01 23:39:25.756', 'long')).toBe(
-      'domingo, 1 de janeiro de 2023',
+    expect(result).not.toBe(
+      'terça-feira, 12 de dezembro de 2023 0:00:00 Horário Padrão de Brasília',
     );
+  });
 
-    expect(normalizeDate('2023-01-16 23:39:25.756')).toBe('16/01/2023');
+  test('should return the expected formatted date for type "long"', () => {
+    const result = normalizeDate('2023-01-01 23:39:25.756Z', 'long');
+    expect(result).toBe('domingo, 1 de janeiro de 2023');
+  });
 
-    expect(normalizeDate('2023-22-12 23:39:25.756', 'long')).toBe(
-      'Invalid Date',
-    );
+  test('should return the expected formatted date for type "numeric"', () => {
+    const result = normalizeDate('2023-01-01 23:39:25.756Z', 'numeric');
+    expect(result).toBe('01/01/2023');
+  });
 
-    expect(normalizeDate('2023-01-01 23:39:25.756')).not.toBe(
-      'domingo, 1 de janeiro de 2023',
-    );
+  test('should return the expected formatted date with default type "numeric"', () => {
+    const result = normalizeDate('2023-01-01');
+    expect(result).toBe('01/01/2023');
+  });
+
+  test('should return "Invalid Date" for invalid date', () => {
+    const invalidDate = '2023-22-12 23:39:25.756';
+    const resultBigger = normalizeDate(invalidDate, 'bigger');
+    const resultLong = normalizeDate(invalidDate, 'long');
+    const resultNumeric = normalizeDate(invalidDate, 'numeric');
+    expect(resultBigger).toBe('Invalid Date');
+    expect(resultLong).toBe('Invalid Date');
+    expect(resultNumeric).toBe('Invalid Date');
+  });
+
+  test('should return different results for different types', () => {
+    const resultLong = normalizeDate('2023-01-01 23:39:25.756Z', 'long');
+    const resultBigger = normalizeDate('2023-01-01 23:39:25.756Z', 'bigger');
+    expect(resultLong).not.toBe(resultBigger);
   });
 });
 

--- a/tests/normalizeDate.spec.ts
+++ b/tests/normalizeDate.spec.ts
@@ -1,5 +1,5 @@
 import 'jest';
-import { normalizeDate } from '../src/';
+import { normalizeDate } from '../src';
 
 describe('normalizeDate', () => {
   test('should return the expected formatted date for type "bigger"', () => {
@@ -43,4 +43,3 @@ describe('normalizeDate', () => {
     expect(resultLong).not.toBe(resultBigger);
   });
 });
-


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
The **normalizeDate** function was removing a day when the date format was ```2023-05-31```. I applied the fix and made some improvements.

### Example:

```normalizeDate("2023-05-31")```

***output***: ```30/05/2023```
***expected output***: ```31/05/2023```

## Type of change

<!-- Check all relevant options. -->

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

- [x] Read the [Contributing Guide](https://github.com/pagnet/blu-utils/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
