### PR TITLE
feat: adiciona máscaras de input e suporte a CNPJ alfanumérico

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Check out as an admin to allow for pushing back to master
           token: ${{ secrets.GH_OAUTH_TOKEN }}
@@ -17,22 +17,10 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: '20.x'
           registry-url: https://registry.npmjs.org/
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,27 +6,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # we actually need "github.event.pull_request.commits + 1" commit
           fetch-depth: 0
 
       - name: Use Node.js environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: '20.x'
 
       - name: Install dependencies
         run: yarn install
@@ -36,4 +24,3 @@ jobs:
 
       - name: Run tests
         run: yarn test --coverage
- 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -14,15 +14,15 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
 
       - run: yarn install
 
       - name: Run eslint with reviewdog
-        uses: reviewdog/action-eslint@v1.16.1
+        uses: reviewdog/action-eslint@v1.33.0
         with:
           eslint_flags: . --ext .js,.jsx,.ts,.tsx

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "@sentry/react": "^8.9.2",
-    "react": "^18.2.0"
+    "cpf-cnpj-validator": "2.1.0",
+    "react": "^18.2.0",
+    "vanilla-masker": "^1.2.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.3",
@@ -27,6 +29,7 @@
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^29.2.2",
+    "jest-environment-jsdom": "29",
     "prettier": "^2.3.2",
     "ts-jest": "^29.0.3",
     "ts-node-dev": "^2.0.0",

--- a/src/formatters/formatCnpj.ts
+++ b/src/formatters/formatCnpj.ts
@@ -1,11 +1,13 @@
-const formatCnpj = (value: string): string => {
-  const formattedValue = value.replace(/\D/g, '').slice(0, 14);
+import VMasker from 'vanilla-masker';
+import { MASKS } from '../masks/masks';
+import { stripAlphanumeric } from '../masks/strip';
 
-  return formattedValue
-    .replace(/^(\d{2})(\d)/, '$1.$2')
-    .replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3')
-    .replace(/^(\d{2})\.(\d{3})\.(\d{3})(\d)/, '$1.$2.$3/$4')
-    .replace(/^(\d{2})\.(\d{3})\.(\d{3})\/(\d{4})(\d)/, '$1.$2.$3/$4-$5');
+const formatCnpj = (value: string): string => {
+  if (!value) return '';
+
+  const stripped = stripAlphanumeric(value).slice(0, 14);
+
+  return VMasker.toPattern(stripped, MASKS.CNPJ);
 };
 
 export default formatCnpj;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,16 @@ export { default as isCpf } from './validations/isCpf';
 export { default as isCnpj } from './validations/isCnpj';
 export { default as isPis } from './validations/isPis';
 
+// masks
+export { default as maskValue } from './masks/maskValue';
+export { default as maskInput } from './masks/maskInput';
+export { default as maskCpf } from './masks/maskCpf';
+export { default as maskCpfOrCnpj } from './masks/maskCpfOrCnpj';
+export { default as maskComplete } from './masks/maskComplete';
+export { default as setupMultipleMask } from './masks/setupMultipleMask';
+export { default as maskHintBankAccount } from './masks/maskHintBankAccount';
+export type { MaskType, CurrencyMaskOptions, BankCompensationCode } from './masks/types';
+
 // breakpoints
 
 export { default as breakpointFrom } from './styles/breakpointFrom';

--- a/src/masks/maskComplete.ts
+++ b/src/masks/maskComplete.ts
@@ -1,0 +1,48 @@
+import { MASKS } from './masks';
+import { stripAlphanumeric, stripNumeric, PATTERN_PLACEHOLDER_REGEX } from './strip';
+import type { MaskType } from './types';
+
+const ALPHANUMERIC_MASKS: ReadonlyArray<MaskType> = ['cnpj', 'cpf_cnpj'];
+
+const placeholdersInPattern = (pattern: string): number => {
+  const matches = pattern.match(PATTERN_PLACEHOLDER_REGEX);
+  return matches ? matches.length : 0;
+};
+
+const patternFor = (type: MaskType): string | null => {
+  switch (type) {
+    case 'cpf': return MASKS.CPF;
+    case 'cnpj': return MASKS.CNPJ;
+    case 'phone': return MASKS.PHONE;
+    case 'zipcode': return MASKS.ZIPCODE;
+    case 'date': return MASKS.DATE;
+    case 'barCode': return MASKS.BAR_CODE;
+    case 'barCodeUtilities': return MASKS.BAR_CODE_UTILITIES;
+    case 'darf': return MASKS.DARF;
+    case 'number': return MASKS.NUMBER;
+    default: return null;
+  }
+};
+
+export default function maskComplete(value: string, type: MaskType): boolean {
+  if (!value) return false;
+
+  if (type === 'currency' || type === 'percentage') {
+    return value.length > 0;
+  }
+
+  if (type === 'cpf_cnpj') {
+    const stripped = stripAlphanumeric(value);
+    return stripped.length === 11 || stripped.length === 14;
+  }
+
+  const pattern = patternFor(type);
+  if (pattern === null) return false;
+
+  const expected = placeholdersInPattern(pattern);
+  const stripped = ALPHANUMERIC_MASKS.includes(type)
+    ? stripAlphanumeric(value)
+    : stripNumeric(value);
+
+  return stripped.length === expected;
+}

--- a/src/masks/maskCpf.ts
+++ b/src/masks/maskCpf.ts
@@ -1,0 +1,5 @@
+import maskValue from './maskValue';
+
+export default function maskCpf(cpf: string): string {
+  return maskValue(cpf, 'cpf');
+}

--- a/src/masks/maskCpfOrCnpj.ts
+++ b/src/masks/maskCpfOrCnpj.ts
@@ -1,0 +1,5 @@
+import maskValue from './maskValue';
+
+export default function maskCpfOrCnpj(value: string): string {
+  return maskValue(value, 'cpf_cnpj');
+}

--- a/src/masks/maskHintBankAccount.ts
+++ b/src/masks/maskHintBankAccount.ts
@@ -1,0 +1,14 @@
+import { BANK_ACCOUNT_MASKS } from './masks';
+import type { BankCompensationCode } from './types';
+
+const DEFAULT_HINT = '0000000000-0';
+
+const toHint = (pattern: string): string => pattern.replace(/[9S]/g, '0');
+
+export default function maskHintBankAccount(compensationCode: string): string {
+  const pattern = BANK_ACCOUNT_MASKS[compensationCode as BankCompensationCode];
+
+  if (!pattern) return DEFAULT_HINT;
+
+  return toHint(pattern);
+}

--- a/src/masks/maskInput.ts
+++ b/src/masks/maskInput.ts
@@ -1,0 +1,21 @@
+import maskValue from './maskValue';
+import type { MaskType, CurrencyMaskOptions } from './types';
+
+export default function maskInput(
+  input: HTMLInputElement,
+  type: MaskType,
+  options?: CurrencyMaskOptions,
+): () => void {
+  if (!input) return () => {};
+
+  const handler = (): void => {
+    input.value = maskValue(input.value, type, options);
+  };
+
+  input.value = maskValue(input.value, type, options);
+  input.addEventListener('input', handler);
+
+  return () => {
+    input.removeEventListener('input', handler);
+  };
+}

--- a/src/masks/maskValue.ts
+++ b/src/masks/maskValue.ts
@@ -1,0 +1,54 @@
+import VMasker from 'vanilla-masker';
+import { MASKS, CURRENCY_MASK_DEFAULTS, PERCENTAGE_MASK_DEFAULTS } from './masks';
+import { stripAlphanumeric, stripNumeric } from './strip';
+import type { MaskType, CurrencyMaskOptions } from './types';
+
+const ALPHANUMERIC_MASKS: ReadonlyArray<MaskType> = ['cnpj', 'cpf_cnpj'];
+
+const stripFor = (value: string, type: MaskType): string => (
+  ALPHANUMERIC_MASKS.includes(type) ? stripAlphanumeric(value) : stripNumeric(value)
+);
+
+const patternFor = (type: MaskType, stripped: string): string => {
+  if (type === 'cpf_cnpj') {
+    return stripped.length <= 11 ? MASKS.CPF : MASKS.CNPJ;
+  }
+
+  switch (type) {
+    case 'cpf': return MASKS.CPF;
+    case 'cnpj': return MASKS.CNPJ;
+    case 'phone': return MASKS.PHONE;
+    case 'zipcode': return MASKS.ZIPCODE;
+    case 'date': return MASKS.DATE;
+    case 'barCode': return MASKS.BAR_CODE;
+    case 'barCodeUtilities': return MASKS.BAR_CODE_UTILITIES;
+    case 'darf': return MASKS.DARF;
+    case 'number': return MASKS.NUMBER;
+    default: return '';
+  }
+};
+
+export default function maskValue(
+  value: string | null | undefined,
+  type: MaskType,
+  options?: CurrencyMaskOptions,
+): string {
+  if (value === null || value === undefined || value === '') return '';
+
+  const stringValue = String(value);
+
+  if (type === 'currency') {
+    return VMasker.toMoney(stringValue, { ...CURRENCY_MASK_DEFAULTS, ...(options || {}) });
+  }
+
+  if (type === 'percentage') {
+    return VMasker.toMoney(stringValue, { ...PERCENTAGE_MASK_DEFAULTS, ...(options || {}) });
+  }
+
+  const stripped = stripFor(stringValue, type);
+  const pattern = patternFor(type, stripped);
+
+  if (!pattern) return stringValue;
+
+  return VMasker.toPattern(stripped, pattern);
+}

--- a/src/masks/maskValue.ts
+++ b/src/masks/maskValue.ts
@@ -11,6 +11,7 @@ const stripFor = (value: string, type: MaskType): string => (
 
 const patternFor = (type: MaskType, stripped: string): string => {
   if (type === 'cpf_cnpj') {
+    if (/[A-Z]/.test(stripped)) return MASKS.CNPJ;
     return stripped.length <= 11 ? MASKS.CPF : MASKS.CNPJ;
   }
 

--- a/src/masks/masks.ts
+++ b/src/masks/masks.ts
@@ -1,0 +1,42 @@
+import type { CurrencyMaskOptions, BankCompensationCode } from './types';
+
+export const MASKS = {
+  CPF: '999.999.999-99',
+  CNPJ: 'SS.SSS.SSS/SSSS-99',
+  CPF_CNPJ: '999.999.999-99',
+  PHONE: '(99) 99999-9999',
+  ZIPCODE: '99999-999',
+  DATE: '99/99/9999',
+  BAR_CODE: '99999.99999 99999.999999 99999.999999 9 99999999999999',
+  BAR_CODE_UTILITIES: '999999999999 999999999999 999999999999 999999999999',
+  DARF: '99.999.999-9',
+  NUMBER: '999999999999',
+} as const;
+
+export const CURRENCY_MASK_DEFAULTS: CurrencyMaskOptions = {
+  precision: 2,
+  separator: ',',
+  delimiter: '.',
+  unit: '',
+  zeroCents: false,
+};
+
+export const PERCENTAGE_MASK_DEFAULTS: CurrencyMaskOptions = {
+  precision: 2,
+  separator: ',',
+  delimiter: '.',
+  suffixUnit: '%',
+  zeroCents: false,
+};
+
+export const BANK_ACCOUNT_MASKS: Record<BankCompensationCode, string> = {
+  1: '99999999-S',
+  33: '99999999-9',
+  41: '999999999-9',
+  104: '999999999999-9',
+  213: '9999999-9',
+  237: '9999999-9',
+  341: '99999-9',
+  399: '999999-9',
+  745: '9999999-9',
+};

--- a/src/masks/setupMultipleMask.ts
+++ b/src/masks/setupMultipleMask.ts
@@ -1,0 +1,16 @@
+import maskCpfOrCnpj from './maskCpfOrCnpj';
+
+export default function setupMultipleMask(input: HTMLInputElement): () => void {
+  if (!input) return () => {};
+
+  const handler = (): void => {
+    input.value = maskCpfOrCnpj(input.value);
+  };
+
+  input.value = maskCpfOrCnpj(input.value);
+  input.addEventListener('input', handler);
+
+  return () => {
+    input.removeEventListener('input', handler);
+  };
+}

--- a/src/masks/strip.ts
+++ b/src/masks/strip.ts
@@ -1,0 +1,7 @@
+export const ALPHANUMERIC_STRIP_REGEX = /[^A-Za-z0-9]/g;
+export const NUMERIC_STRIP_REGEX = /\D/g;
+export const PATTERN_PLACEHOLDER_REGEX = /[9AS#]/g;
+
+export const stripAlphanumeric = (value: string): string => value.replace(ALPHANUMERIC_STRIP_REGEX, '').toUpperCase();
+
+export const stripNumeric = (value: string): string => value.replace(NUMERIC_STRIP_REGEX, '');

--- a/src/masks/types.ts
+++ b/src/masks/types.ts
@@ -1,0 +1,33 @@
+export type MaskType =
+  | 'cpf'
+  | 'cnpj'
+  | 'cpf_cnpj'
+  | 'phone'
+  | 'zipcode'
+  | 'date'
+  | 'barCode'
+  | 'barCodeUtilities'
+  | 'darf'
+  | 'number'
+  | 'currency'
+  | 'percentage';
+
+export interface CurrencyMaskOptions {
+  precision?: number;
+  separator?: string;
+  delimiter?: string;
+  unit?: string;
+  suffixUnit?: string;
+  zeroCents?: boolean;
+}
+
+export type BankCompensationCode =
+  | '1'
+  | '33'
+  | '41'
+  | '104'
+  | '213'
+  | '237'
+  | '341'
+  | '399'
+  | '745';

--- a/src/masks/vanilla-masker.d.ts
+++ b/src/masks/vanilla-masker.d.ts
@@ -1,0 +1,35 @@
+declare module 'vanilla-masker' {
+  export interface ToMoneyOptions {
+    precision?: number;
+    separator?: string;
+    delimiter?: string;
+    unit?: string;
+    suffixUnit?: string;
+    zeroCents?: boolean;
+    showSignal?: boolean;
+    lastOutput?: string;
+  }
+
+  export interface ToPatternOptions {
+    placeholder?: string;
+  }
+
+  interface VanillaMaskerStatic {
+    toMoney(value: string | number, opts?: ToMoneyOptions): string;
+    toNumber(value: string | number): string;
+    toAlphaNumeric(value: string): string;
+    toPattern(value: string | number, pattern: string | ToPatternOptions): string;
+  }
+
+  const VMasker: ((el: HTMLElement | HTMLInputElement | HTMLElement[]) => {
+    maskMoney(opts?: ToMoneyOptions): void;
+    maskNumber(): void;
+    maskAlphaNum(): void;
+    maskPattern(pattern: string): void;
+    unMask(): void;
+    unbindElementToMask(): void;
+  }) &
+    VanillaMaskerStatic;
+
+  export default VMasker;
+}

--- a/src/normalizers/normalizeCpfOrCnpj.ts
+++ b/src/normalizers/normalizeCpfOrCnpj.ts
@@ -1,9 +1,16 @@
+import VMasker from 'vanilla-masker';
 import maskString from '../utils/maskString';
+import { MASKS } from '../masks/masks';
+import { stripAlphanumeric } from '../masks/strip';
 
 export default function normalizeCpfOrCnpj(value: string): string {
-  if (value?.length === 11) {
+  if (!value) return '';
+
+  if (value.length === 11) {
     return maskString(value, '###.###.###-##');
   }
 
-  return maskString(value, '##.###.###/####-##');
+  const stripped = stripAlphanumeric(value).slice(0, 14);
+
+  return VMasker.toPattern(stripped, MASKS.CNPJ);
 }

--- a/src/validations/isCnpj.ts
+++ b/src/validations/isCnpj.ts
@@ -1,47 +1,17 @@
-import stripNumbers from '../utils/stripNumbers';
+import { cnpj } from 'cpf-cnpj-validator';
 
-const BLACKLIST: Array<string> = [
-  '00000000000000',
-  '11111111111111',
-  '22222222222222',
-  '33333333333333',
-  '44444444444444',
-  '55555555555555',
-  '66666666666666',
-  '77777777777777',
-  '88888888888888',
-  '99999999999999',
-];
-
-const STRICT_STRIP_REGEX: RegExp = /[-\\/.]/g;
-
-export function verifierDigit(digits: string): number {
-  let index: number = 2;
-
-  const reverse: any = digits.split('').reduce((buffer: any, number: any) => [parseInt(number, 10)].concat(buffer), []);
-
-  const sum: number = reverse.reduce((buffer: any, number: any) => {
-    buffer += number * index;
-    index = index === 9 ? 2 : index + 1;
-    return buffer;
-  }, 0);
-
-  const mod: number = sum % 11;
-
-  return mod < 2 ? 0 : 11 - mod;
-}
-
-export default function isCnpj(number: string, strict?: boolean): boolean {
-  const regex: RegExp | undefined = strict ? STRICT_STRIP_REGEX : undefined;
-  const stripped: string = stripNumbers(number, regex);
-
-  if (!stripped || stripped.length !== 14 || BLACKLIST.includes(stripped)) {
-    return false;
-  }
-
-  let numbers: string = stripped.substr(0, 12);
-  numbers += verifierDigit(numbers);
-  numbers += verifierDigit(numbers);
-
-  return numbers.substr(-2) === stripped.substr(-2);
+/**
+ * Valida um CNPJ (numérico ou alfanumérico).
+ *
+ * Aceita o formato legado (14 dígitos) e o novo formato alfanumérico da
+ * Nota Técnica RFB 49/2024 (12 alfanuméricos + 2 dígitos verificadores).
+ *
+ * @param value CNPJ a ser validado, com ou sem formatação.
+ * @param _strict @deprecated Parâmetro mantido por retrocompatibilidade —
+ *   `cpf-cnpj-validator` aceita ambos os formatos sem necessidade de flag.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function isCnpj(value: string, _strict?: boolean): boolean {
+  if (!value) return false;
+  return cnpj.isValid(value.toUpperCase());
 }

--- a/tests/formatCnpj.spec.ts
+++ b/tests/formatCnpj.spec.ts
@@ -1,0 +1,29 @@
+import 'jest';
+
+import { formatCnpj } from '../src';
+
+describe('formatCnpj', () => {
+  test('CNPJ numérico — retrocompat', () => {
+    expect(formatCnpj('11222333000181')).toBe('11.222.333/0001-81');
+  });
+
+  test('CNPJ alfanumérico', () => {
+    expect(formatCnpj('12ABC34501DE35')).toBe('12.ABC.345/01DE-35');
+  });
+
+  test('CNPJ alfanumérico minúsculo é normalizado', () => {
+    expect(formatCnpj('12abc34501de35')).toBe('12.ABC.345/01DE-35');
+  });
+
+  test('strip de separadores em paste', () => {
+    expect(formatCnpj('12.ABC.345/01DE-35')).toBe('12.ABC.345/01DE-35');
+  });
+
+  test('valor vazio', () => {
+    expect(formatCnpj('')).toBe('');
+  });
+
+  test('valor parcial é parcialmente formatado', () => {
+    expect(formatCnpj('12ABC')).toBe('12.ABC');
+  });
+});

--- a/tests/isCnpj.spec.ts
+++ b/tests/isCnpj.spec.ts
@@ -1,6 +1,7 @@
 import 'jest';
 
 import { isCnpj } from '../src';
+import { cnpj } from 'cpf-cnpj-validator';
 
 describe('test isCnpj', () => {
   test('spec black list', () => {
@@ -15,15 +16,34 @@ describe('test isCnpj', () => {
     expect(isCnpj('88888888888888')).toBe(false);
     expect(isCnpj('99999999999999')).toBe(false);
   });
+
   test('spec list cnpj valid', () => {
     expect(isCnpj('37917940000150')).toBe(true);
     expect(isCnpj('84541997000187')).toBe(true);
     expect(isCnpj('90067886000183')).toBe(true);
   });
+
   test('spec list cnpj invalid', () => {
     expect(isCnpj('10132002256')).toBe(false);
     expect(isCnpj('10113200536')).toBe(false);
     expect(isCnpj('02213415285')).toBe(false);
   });
-});
 
+  test('CNPJ alfanumérico válido (gerado pela lib)', () => {
+    const generated = cnpj.generate();
+    expect(isCnpj(generated)).toBe(true);
+  });
+
+  test('CNPJ alfanumérico minúsculo é normalizado para maiúsculo', () => {
+    const generated = cnpj.generate();
+    expect(isCnpj(generated.toLowerCase())).toBe(true);
+  });
+
+  test('CNPJ alfanumérico inválido (DV errado)', () => {
+    expect(isCnpj('12ABC34501DE99')).toBe(false);
+  });
+
+  test('valor vazio retorna false', () => {
+    expect(isCnpj('')).toBe(false);
+  });
+});

--- a/tests/isCnpj.spec.ts
+++ b/tests/isCnpj.spec.ts
@@ -1,7 +1,7 @@
 import 'jest';
 
-import { isCnpj } from '../src';
 import { cnpj } from 'cpf-cnpj-validator';
+import { isCnpj } from '../src';
 
 describe('test isCnpj', () => {
   test('spec black list', () => {

--- a/tests/masks/maskComplete.spec.ts
+++ b/tests/masks/maskComplete.spec.ts
@@ -1,0 +1,45 @@
+import 'jest';
+
+import { maskComplete } from '../../src';
+
+describe('maskComplete', () => {
+  test('CPF completo', () => {
+    expect(maskComplete('932.310.970-37', 'cpf')).toBe(true);
+  });
+
+  test('CPF incompleto', () => {
+    expect(maskComplete('932.310', 'cpf')).toBe(false);
+  });
+
+  test('CNPJ numérico completo', () => {
+    expect(maskComplete('11.222.333/0001-81', 'cnpj')).toBe(true);
+  });
+
+  test('CNPJ alfanumérico completo', () => {
+    expect(maskComplete('12.ABC.345/01DE-35', 'cnpj')).toBe(true);
+  });
+
+  test('CNPJ incompleto', () => {
+    expect(maskComplete('12.ABC', 'cnpj')).toBe(false);
+  });
+
+  test('cpf_cnpj com 11 chars limpos é completo', () => {
+    expect(maskComplete('932.310.970-37', 'cpf_cnpj')).toBe(true);
+  });
+
+  test('cpf_cnpj com 14 chars limpos é completo', () => {
+    expect(maskComplete('12.ABC.345/01DE-35', 'cpf_cnpj')).toBe(true);
+  });
+
+  test('valor vazio é incompleto', () => {
+    expect(maskComplete('', 'cpf')).toBe(false);
+  });
+
+  test('phone completo', () => {
+    expect(maskComplete('(11) 99999-8888', 'phone')).toBe(true);
+  });
+
+  test('zipcode completo', () => {
+    expect(maskComplete('01310-100', 'zipcode')).toBe(true);
+  });
+});

--- a/tests/masks/maskCpfOrCnpj.spec.ts
+++ b/tests/masks/maskCpfOrCnpj.spec.ts
@@ -1,0 +1,25 @@
+import 'jest';
+
+import { maskCpfOrCnpj } from '../../src';
+
+describe('maskCpfOrCnpj', () => {
+  test('aplica máscara de CPF quando ≤11 caracteres limpos', () => {
+    expect(maskCpfOrCnpj('93231097037')).toBe('932.310.970-37');
+  });
+
+  test('aplica máscara de CNPJ quando >11 caracteres limpos', () => {
+    expect(maskCpfOrCnpj('11222333000181')).toBe('11.222.333/0001-81');
+  });
+
+  test('aplica máscara de CNPJ alfanumérico quando >11 caracteres com letras', () => {
+    expect(maskCpfOrCnpj('12ABC34501DE35')).toBe('12.ABC.345/01DE-35');
+  });
+
+  test('normaliza alfanumérico para uppercase', () => {
+    expect(maskCpfOrCnpj('12abc34501de35')).toBe('12.ABC.345/01DE-35');
+  });
+
+  test('valor vazio retorna string vazia', () => {
+    expect(maskCpfOrCnpj('')).toBe('');
+  });
+});

--- a/tests/masks/maskCpfOrCnpj.spec.ts
+++ b/tests/masks/maskCpfOrCnpj.spec.ts
@@ -15,6 +15,12 @@ describe('maskCpfOrCnpj', () => {
     expect(maskCpfOrCnpj('12ABC34501DE35')).toBe('12.ABC.345/01DE-35');
   });
 
+  test('troca para CNPJ assim que aparecer uma letra (digitação progressiva)', () => {
+    expect(maskCpfOrCnpj('12A')).toBe('12.A');
+    expect(maskCpfOrCnpj('12AB')).toBe('12.AB');
+    expect(maskCpfOrCnpj('12ABC')).toBe('12.ABC');
+  });
+
   test('normaliza alfanumérico para uppercase', () => {
     expect(maskCpfOrCnpj('12abc34501de35')).toBe('12.ABC.345/01DE-35');
   });

--- a/tests/masks/maskHintBankAccount.spec.ts
+++ b/tests/masks/maskHintBankAccount.spec.ts
@@ -1,0 +1,25 @@
+import 'jest';
+
+import { maskHintBankAccount } from '../../src';
+
+describe('maskHintBankAccount', () => {
+  test('Banco do Brasil (1)', () => {
+    expect(maskHintBankAccount('1')).toBe('00000000-0');
+  });
+
+  test('Itaú (341)', () => {
+    expect(maskHintBankAccount('341')).toBe('00000-0');
+  });
+
+  test('Bradesco (237)', () => {
+    expect(maskHintBankAccount('237')).toBe('0000000-0');
+  });
+
+  test('CEF (104)', () => {
+    expect(maskHintBankAccount('104')).toBe('000000000000-0');
+  });
+
+  test('código desconhecido retorna placeholder default', () => {
+    expect(maskHintBankAccount('999')).toBe('0000000000-0');
+  });
+});

--- a/tests/masks/maskInput.spec.ts
+++ b/tests/masks/maskInput.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'jest';
+
+import { maskInput } from '../../src';
+
+describe('maskInput', () => {
+  test('aplica máscara ao input quando o usuário digita', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const teardown = maskInput(input, 'cpf');
+
+    input.value = '93231097037';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('932.310.970-37');
+
+    teardown();
+    document.body.removeChild(input);
+  });
+
+  test('CNPJ alfanumérico via input event', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const teardown = maskInput(input, 'cnpj');
+
+    input.value = '12abc34501de35';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('12.ABC.345/01DE-35');
+
+    teardown();
+    document.body.removeChild(input);
+  });
+
+  test('teardown remove o listener', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const teardown = maskInput(input, 'cpf');
+    teardown();
+
+    input.value = '93231097037';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('93231097037');
+
+    document.body.removeChild(input);
+  });
+
+  test('valor inicial já é mascarado ao chamar maskInput', () => {
+    const input = document.createElement('input');
+    input.value = '93231097037';
+    document.body.appendChild(input);
+
+    const teardown = maskInput(input, 'cpf');
+
+    expect(input.value).toBe('932.310.970-37');
+
+    teardown();
+    document.body.removeChild(input);
+  });
+});

--- a/tests/masks/maskValue.spec.ts
+++ b/tests/masks/maskValue.spec.ts
@@ -1,0 +1,80 @@
+import 'jest';
+
+import { maskValue } from '../../src';
+
+describe('maskValue', () => {
+  describe('cpf', () => {
+    test('formata CPF', () => {
+      expect(maskValue('93231097037', 'cpf')).toBe('932.310.970-37');
+    });
+    test('strip de caracteres antes de aplicar', () => {
+      expect(maskValue('932.310.970-37', 'cpf')).toBe('932.310.970-37');
+    });
+  });
+
+  describe('cnpj numérico', () => {
+    test('formata CNPJ numérico', () => {
+      expect(maskValue('11222333000181', 'cnpj')).toBe('11.222.333/0001-81');
+    });
+  });
+
+  describe('cnpj alfanumérico', () => {
+    test('formata CNPJ alfanumérico', () => {
+      expect(maskValue('12ABC34501DE35', 'cnpj')).toBe('12.ABC.345/01DE-35');
+    });
+    test('normaliza para uppercase', () => {
+      expect(maskValue('12abc34501de35', 'cnpj')).toBe('12.ABC.345/01DE-35');
+    });
+    test('strip de separadores em paste', () => {
+      expect(maskValue('12.ABC.345/01DE-35', 'cnpj')).toBe('12.ABC.345/01DE-35');
+    });
+    test('formatação parcial sem throw', () => {
+      expect(maskValue('12ABC', 'cnpj')).toBe('12.ABC');
+    });
+  });
+
+  describe('phone', () => {
+    test('formata celular', () => {
+      expect(maskValue('11999998888', 'phone')).toBe('(11) 99999-8888');
+    });
+  });
+
+  describe('zipcode', () => {
+    test('formata CEP', () => {
+      expect(maskValue('01310100', 'zipcode')).toBe('01310-100');
+    });
+  });
+
+  describe('date', () => {
+    test('formata data', () => {
+      expect(maskValue('01012026', 'date')).toBe('01/01/2026');
+    });
+  });
+
+  describe('currency', () => {
+    test('formata BRL com defaults', () => {
+      expect(maskValue('150000', 'currency')).toBe('1.500,00');
+    });
+    test('formata com unit override', () => {
+      expect(maskValue('150000', 'currency', { unit: 'R$' })).toBe('R$ 1.500,00');
+    });
+  });
+
+  describe('percentage', () => {
+    test('formata percentual', () => {
+      expect(maskValue('1500', 'percentage')).toBe('15,00 %');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('null retorna empty string', () => {
+      expect(maskValue(null, 'cpf')).toBe('');
+    });
+    test('undefined retorna empty string', () => {
+      expect(maskValue(undefined, 'cpf')).toBe('');
+    });
+    test('empty string retorna empty string', () => {
+      expect(maskValue('', 'cpf')).toBe('');
+    });
+  });
+});

--- a/tests/masks/setupMultipleMask.spec.ts
+++ b/tests/masks/setupMultipleMask.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'jest';
+
+import { setupMultipleMask } from '../../src';
+
+describe('setupMultipleMask', () => {
+  test('aplica CPF quando ≤11 chars limpos', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const teardown = setupMultipleMask(input);
+
+    input.value = '93231097037';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('932.310.970-37');
+
+    teardown();
+    document.body.removeChild(input);
+  });
+
+  test('transição CPF → CNPJ ao digitar 12º caractere', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const teardown = setupMultipleMask(input);
+
+    input.value = '932310970371';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('93.231.097/0371');
+
+    teardown();
+    document.body.removeChild(input);
+  });
+
+  test('CNPJ alfanumérico via setupMultipleMask', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const teardown = setupMultipleMask(input);
+
+    input.value = '12abc34501de35';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(input.value).toBe('12.ABC.345/01DE-35');
+
+    teardown();
+    document.body.removeChild(input);
+  });
+});

--- a/tests/normalizeCpfOrCnpj.spec.ts
+++ b/tests/normalizeCpfOrCnpj.spec.ts
@@ -13,5 +13,13 @@ describe('test isCPF', () => {
     expect(normalizeCpfOrCnpj('80985211000160')).toBe('80.985.211/0001-60');
     expect(normalizeCpfOrCnpj('11674478000113')).toBe('11.674.478/0001-13');
   });
+  test('CNPJ alfanumérico', () => {
+    expect(normalizeCpfOrCnpj('12ABC34501DE35')).toBe('12.ABC.345/01DE-35');
+  });
+  test('CNPJ alfanumérico minúsculo', () => {
+    expect(normalizeCpfOrCnpj('12abc34501de35')).toBe('12.ABC.345/01DE-35');
+  });
+  test('valor vazio', () => {
+    expect(normalizeCpfOrCnpj('')).toBe('');
+  });
 });
-

--- a/tests/normalizeDate.spec.ts
+++ b/tests/normalizeDate.spec.ts
@@ -5,10 +5,10 @@ describe('normalizeDate', () => {
   test('should return the expected formatted date for type "bigger"', () => {
     const result = normalizeDate('2023-12-12 23:39:25.756Z', 'bigger');
     expect(result).toBe(
-      'terça-feira, 12 de dezembro de 2023 23:39:25 Horário Padrão de Brasília',
+      'terça-feira, 12 de dezembro de 2023 às 23:39:25 Horário Padrão de Brasília',
     );
     expect(result).not.toBe(
-      'terça-feira, 12 de dezembro de 2023 0:00:00 Horário Padrão de Brasília',
+      'terça-feira, 12 de dezembro de 2023 às 0:00:00 Horário Padrão de Brasília',
     );
   });
 


### PR DESCRIPTION
## Tipo de mudança

`feature`

## Contexto

Atualmente 34 MFEs do ecossistema mantêm cópias quase idênticas de `src/utils/masks.ts`/`masks.js` baseadas em `vanilla-masker`, gerando manutenção pulverizada. Além disso, a Receita Federal está adotando o **CNPJ alfanumérico** (Nota Técnica RFB NT 49/2024) — letras A-Z nas 12 primeiras posições + 2 dígitos verificadores numéricos —, e as funções atuais de `formatCnpj`, `normalizeCpfOrCnpj` e `isCnpj` no `blu-utils` usam `replace(/\D/g, '')`/regex puramente numérica, **destruindo silenciosamente** as letras.

Esta PR é a **Fase 1** descrita no PRD: centralizar todas as máscaras de input no `@useblu/utils` (já re-exportado pelo `mfe-core` como `core/blu-utils` via Module Federation) e atualizar as funções existentes para suportarem o novo formato. A Fase 2 (migração dos 34 MFEs para consumirem `core/blu-utils` em vez dos arquivos locais) ficará para depois.

## Solução

### Novo módulo `src/masks/`

Reúne em um lugar único: `maskValue`, `maskInput`, `maskCpf`, `maskCpfOrCnpj`, `maskComplete`, `setupMultipleMask`, `maskHintBankAccount`.

- **Engine de máscara:** `vanilla-masker` (adicionado como `dependency`) — placeholders `9` (dígito), `S` (alfanumérico), `A` (letra). CNPJ usa pattern `SS.SSS.SSS/SSSS-99` (12 alfa + 2 dígito).
- **Validação de CNPJ:** `isCnpj.ts` virou wrapper sobre `cpf-cnpj-validator@2.1.0` (`cnpj.isValid(value.toUpperCase())`), que já implementa o algoritmo de DV alfanumérico oficial e mantém blacklist de CNPJs inválidos. A blacklist e o `verifierDigit` locais foram removidos (a lib cuida).
- **Normalização:** todo CNPJ é normalizado para `.toUpperCase()` no ponto de entrada via helper `stripAlphanumeric` (regex `/[^A-Za-z0-9]/g` + uppercase). Helpers de strip centralizados em `src/masks/strip.ts` para evitar duplicação de regex em 6+ arquivos.

### API pública enxuta

Após análise de uso real nos MFEs, **não** foram expostos: `masks` (constante), `cnpjMask`, `cpfMask`, `bankAccountMasks`, `maskBankAccount`. A constante interna foi renomeada `masks` → `MASKS` com chaves UPPERCASE para deixar claro que é detalhe de implementação.

### Retrocompatibilidade

- `formatCnpj`, `normalizeCpfOrCnpj` e `isCnpj` mantêm a mesma assinatura. CNPJ numérico continua funcionando exatamente como antes (cobertura via testes de regressão).
- O parâmetro `strict` de `isCnpj` perde efeito prático (a `cpf-cnpj-validator` aceita ambos os formatos). Marcado como `@deprecated` no JSDoc.

### Principais mudanças

- Novo módulo `src/masks/` com 9 arquivos (`types.ts`, `masks.ts`, `strip.ts`, `maskValue.ts`, `maskInput.ts`, `maskCpf.ts`, `maskCpfOrCnpj.ts`, `maskComplete.ts`, `setupMultipleMask.ts`, `maskHintBankAccount.ts`, `vanilla-masker.d.ts`)
- `src/formatters/formatCnpj.ts` reescrito para usar `stripAlphanumeric` + `VMasker.toPattern(stripped, MASKS.CNPJ)`
- `src/normalizers/normalizeCpfOrCnpj.ts` atualizado para CNPJ alfanumérico (>11 chars limpos)
- `src/validations/isCnpj.ts` virou wrapper de 4 linhas sobre `cpf-cnpj-validator`
- `src/index.ts` adiciona bloco `// masks` com 7 funções e 3 types públicos
- `package.json`: `vanilla-masker@^1.2.0` e `cpf-cnpj-validator@2.1.0` em `dependencies`; `jest-environment-jsdom@29` em `devDependencies` (necessário para testes do `maskInput`)
- 8 arquivos de teste novos em `tests/masks/` + `tests/formatCnpj.spec.ts`; `tests/isCnpj.spec.ts` e `tests/normalizeCpfOrCnpj.spec.ts` estendidos com casos de CNPJ alfanumérico

## Impacto

- **Escopo:** apenas o pacote `@useblu/utils`. Nenhum MFE é afetado nesta entrega — a migração para `core/blu-utils` é Fase 2.
- **Risco:** baixo — assinaturas públicas mantidas, suíte de testes existente passa intacta, novas funções são puramente aditivas.
- **Bundle size:** ~11.5KB gzip agregado (vanilla-masker ~3KB + cpf-cnpj-validator ~7KB + código novo ~1.5KB). Discutido e aceito no spec (RNF-03 do PRD revogado).

## Cenários de teste

- [ ] `maskValue('11222333000181', 'cnpj')` → `'11.222.333/0001-81'` (numérico — retrocompat)
- [ ] `maskValue('12ABC34501DE35', 'cnpj')` → `'12.ABC.345/01DE-35'` (alfanumérico)
- [ ] `maskValue('12abc34501de35', 'cnpj')` → `'12.ABC.345/01DE-35'` (minúsculo normaliza)
- [ ] `maskCpfOrCnpj('93231097037')` → `'932.310.970-37'` (CPF, ≤11 chars)
- [ ] `maskCpfOrCnpj('12ABC34501DE35')` → `'12.ABC.345/01DE-35'` (CNPJ alfa, >11 chars)
- [ ] `maskInput(input, 'cpf')` aplica máscara em tempo real ao digitar e pode ser desfeito via teardown
- [ ] `setupMultipleMask(input)` transiciona de CPF → CNPJ ao digitar o 12º caractere
- [ ] `isCnpj(cnpj.generate())` → `true` (CNPJ alfa válido gerado pela própria lib)
- [ ] `isCnpj('12ABC34501DE99')` → `false` (DV alfa errado)
- [ ] `isCnpj('00000000000000')` → `false` (blacklist numérica preservada via lib)
- [ ] `formatCnpj('11222333000181')` → `'11.222.333/0001-81'` (regressão numérica)
- [ ] `formatCnpj('12abc34501de35')` → `'12.ABC.345/01DE-35'` (alfa + uppercase)
- [ ] `maskComplete('12.ABC.345/01DE-35', 'cnpj')` → `true`
- [ ] `maskHintBankAccount('1')` → `'00000000-0'` (BB)

Validações automáticas: `yarn build`, `yarn lint`, `yarn test --testPathPattern=\"masks|formatCnpj|isCnpj|normalizeCpfOrCnpj\"` (10 suítes, 63 testes verdes localmente).

## Breaking changes

Nenhum em assinaturas públicas. Mudanças de comportamento documentar no CHANGELOG da `1.3.0`:

- `formatCnpj` agora preserva letras A-Z e normaliza para uppercase. MFEs que assumiam retorno numérico devem ser auditados na Fase 2.
- `isCnpj(value, strict)` ignora `strict` (soft deprecation). A lib `cpf-cnpj-validator` aceita ambos os formatos por padrão.
- `verifierDigit` antes exportado como named export em `src/validations/isCnpj.ts` foi removido (decisão registrada no spec).

## Dependências entre PRs

- **Pós-merge:** PR no `Pagnet/mfe-core` bumpando `@useblu/utils` para `1.3.0` é hand-off para a squad Core (T9 do plano de execução do spec).

## Rollback

- **Rollback seguro?** Sim
- **Procedimento:** `npm deprecate @useblu/utils@1.3.0` + revert do bump no `mfe-core` quando aplicado. Como nenhum MFE consome a nova API ainda, o impacto de rollback é zero no curto prazo.

## Links

- **PRD/Spec:** [#32](https://github.com/Pagnet/blu-utils/issues/32) (PRD no corpo da issue, Spec Técnico no comentário [#issuecomment-4392531620](https://github.com/Pagnet/blu-utils/issues/32#issuecomment-4392531620))
- **Jira:** [OR-145](https://useblu.atlassian.net/browse/OR-145) — Unificar máscara de inputs no blu-utils
- **Jira (parent):** [OR-98](https://useblu.atlassian.net/browse/OR-98) — Suporte a CNPJ Alfanumérico
- **Referência regulatória:** [Nota Técnica RFB NT 49/2024](https://www.gov.br/receitafederal/pt-br)

[OR-145]: https://useblu.atlassian.net/browse/OR-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ