### PR TITLE
OR-145: corrige máscaras de agência e conta (Itaú, Caixa, BB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useblu/utils",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": false,
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/masks/maskBankAccount.ts
+++ b/src/masks/maskBankAccount.ts
@@ -1,10 +1,6 @@
 import VMasker from 'vanilla-masker';
-import {
-  BANK_ACCOUNT_MASKS,
-  DEFAULT_BANK_ACCOUNT_MASK,
-  ALPHANUMERIC_BANK_CODES,
-} from './masks';
-import { stripAlphanumeric, stripNumeric } from './strip';
+import { BANK_ACCOUNT_MASKS, DEFAULT_BANK_ACCOUNT_MASK } from './masks';
+import { stripNumeric } from './strip';
 import type { BankCompensationCode } from './types';
 
 export default function maskBankAccount(
@@ -15,9 +11,6 @@ export default function maskBankAccount(
 
   const code = compensationCode as BankCompensationCode;
   const pattern = BANK_ACCOUNT_MASKS[code] ?? DEFAULT_BANK_ACCOUNT_MASK;
-  const stripped = ALPHANUMERIC_BANK_CODES.includes(code)
-    ? stripAlphanumeric(String(value))
-    : stripNumeric(String(value));
 
-  return VMasker.toPattern(stripped, pattern);
+  return VMasker.toPattern(stripNumeric(String(value)), pattern);
 }

--- a/src/masks/maskBankBranch.ts
+++ b/src/masks/maskBankBranch.ts
@@ -1,17 +1,18 @@
 import VMasker from 'vanilla-masker';
-import { BANK_BRANCH_MASKS, DEFAULT_BANK_BRANCH_MASK } from './masks';
+import { DEFAULT_BANK_BRANCH_MASK } from './masks';
 import { stripNumeric } from './strip';
-import type { BankCompensationCode } from './types';
 
 export default function maskBankBranch(
   value: string | null | undefined,
+  // Mantido por compatibilidade de API e simetria com maskBankAccount: a
+  // agência usa sempre 4 dígitos, independente do banco (o DV, quando há, é
+  // calculado pelo backend).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   compensationCode?: string,
 ): string {
   if (value === null || value === undefined || value === '') return '';
 
   const stripped = stripNumeric(String(value));
-  const pattern = BANK_BRANCH_MASKS[compensationCode as BankCompensationCode]
-    ?? DEFAULT_BANK_BRANCH_MASK;
 
-  return VMasker.toPattern(stripped, pattern);
+  return VMasker.toPattern(stripped, DEFAULT_BANK_BRANCH_MASK);
 }

--- a/src/masks/maskComplete.ts
+++ b/src/masks/maskComplete.ts
@@ -2,9 +2,7 @@ import {
   MASKS,
   DEFAULT_BANK_BRANCH_MASK,
   DEFAULT_BANK_ACCOUNT_MASK,
-  BANK_BRANCH_MASKS,
   BANK_ACCOUNT_MASKS,
-  ALPHANUMERIC_BANK_CODES,
 } from './masks';
 import { stripAlphanumeric, stripNumeric, PATTERN_PLACEHOLDER_REGEX } from './strip';
 import type { MaskType, BankCompensationCode } from './types';
@@ -31,13 +29,7 @@ const patternFor = (
     case 'barCodeUtilities': return MASKS.BAR_CODE_UTILITIES;
     case 'darf': return MASKS.DARF;
     case 'number': return MASKS.NUMBER;
-    case 'bank_branch': {
-      if (compensationCode) {
-        const mapped = BANK_BRANCH_MASKS[compensationCode as BankCompensationCode];
-        if (mapped) return mapped;
-      }
-      return DEFAULT_BANK_BRANCH_MASK;
-    }
+    case 'bank_branch': return DEFAULT_BANK_BRANCH_MASK;
     case 'bank_account': {
       if (compensationCode) {
         const mapped = BANK_ACCOUNT_MASKS[compensationCode as BankCompensationCode];
@@ -76,11 +68,7 @@ export default function maskComplete(
 
   const expected = placeholdersInPattern(pattern);
 
-  const isAlphanumeric = ALPHANUMERIC_MASKS.includes(type)
-    || (
-      (type === 'bank_account' || type === 'bank_branch')
-      && ALPHANUMERIC_BANK_CODES.includes(compensationCode as BankCompensationCode)
-    );
+  const isAlphanumeric = ALPHANUMERIC_MASKS.includes(type);
 
   const stripped = isAlphanumeric
     ? stripAlphanumeric(value)

--- a/src/masks/maskValue.ts
+++ b/src/masks/maskValue.ts
@@ -5,9 +5,7 @@ import {
   PERCENTAGE_MASK_DEFAULTS,
   DEFAULT_BANK_BRANCH_MASK,
   DEFAULT_BANK_ACCOUNT_MASK,
-  BANK_BRANCH_MASKS,
   BANK_ACCOUNT_MASKS,
-  ALPHANUMERIC_BANK_CODES,
 } from './masks';
 import { stripAlphanumeric, stripNumeric } from './strip';
 import type { MaskType, CurrencyMaskOptions, BankCompensationCode } from './types';
@@ -23,23 +21,9 @@ export interface MaskValueOptions extends CurrencyMaskOptions {
 
 const ALPHANUMERIC_MASKS: ReadonlyArray<MaskType> = ['cnpj', 'cpf_cnpj'];
 
-const stripFor = (value: string, type: MaskType, compensationCode?: string): string => {
+const stripFor = (value: string, type: MaskType): string => {
   if (ALPHANUMERIC_MASKS.includes(type)) return stripAlphanumeric(value);
-  if (
-    (type === 'bank_account' || type === 'bank_branch')
-    && ALPHANUMERIC_BANK_CODES.includes(compensationCode as BankCompensationCode)
-  ) {
-    return stripAlphanumeric(value);
-  }
   return stripNumeric(value);
-};
-
-const bankBranchPattern = (code?: string): string => {
-  if (code) {
-    const mapped = BANK_BRANCH_MASKS[code as BankCompensationCode];
-    if (mapped) return mapped;
-  }
-  return DEFAULT_BANK_BRANCH_MASK;
 };
 
 const bankAccountPattern = (code?: string): string => {
@@ -71,7 +55,7 @@ const patternFor = (
     case 'barCodeUtilities': return MASKS.BAR_CODE_UTILITIES;
     case 'darf': return MASKS.DARF;
     case 'number': return MASKS.NUMBER;
-    case 'bank_branch': return bankBranchPattern(compensationCode);
+    case 'bank_branch': return DEFAULT_BANK_BRANCH_MASK;
     case 'bank_account': return bankAccountPattern(compensationCode);
     default: return '';
   }
@@ -94,7 +78,7 @@ export default function maskValue(
     return VMasker.toMoney(stringValue, { ...PERCENTAGE_MASK_DEFAULTS, ...(options || {}) });
   }
 
-  const stripped = stripFor(stringValue, type, options?.compensationCode);
+  const stripped = stripFor(stringValue, type);
   const pattern = patternFor(type, stripped, options?.compensationCode);
 
   if (!pattern) return stringValue;

--- a/src/masks/masks.ts
+++ b/src/masks/masks.ts
@@ -47,7 +47,7 @@ export const BANK_ACCOUNT_MASKS: Partial<Record<BankCompensationCode, string>> =
   33: '99999999-9',
   41: '999999999-9',
   104: '999999999-9',
-  213: '9999999-9',
+  213: '99999-9',
   237: '9999999-9',
   341: '99999-9',
   399: '999999-9',

--- a/src/masks/masks.ts
+++ b/src/masks/masks.ts
@@ -30,17 +30,11 @@ export const PERCENTAGE_MASK_DEFAULTS: CurrencyMaskOptions = {
   zeroCents: false,
 };
 
-// Toda agência bancária é informada com 4 dígitos no frontend. Quando o banco
-// exige dígito verificador na agência (BB, Banrisul, Bradesco, Arbi), o DV é
-// calculado/validado pelo backend a partir dos 4 dígitos — não pelo input.
-// Por isso não há override por banco aqui: todos usam DEFAULT_BANK_BRANCH_MASK.
-export const BANK_BRANCH_MASKS: Partial<Record<BankCompensationCode, string>> = {};
-
+// Toda agência bancária é informada com 4 dígitos no frontend; quando há DV
+// na agência (BB, Banrisul, Bradesco, Arbi) ele é calculado/validado pelo
+// backend a partir desses 4 dígitos. Por isso a agência não tem máscara por
+// banco — todos usam este default.
 export const DEFAULT_BANK_BRANCH_MASK = '9999';
-
-// Nenhum banco usa DV alfanumérico em conta: o backend valida DV apenas
-// numérico (/-\d/) e a UI orienta o usuário a trocar "X" por "0" (ex.: BB).
-export const ALPHANUMERIC_BANK_CODES: ReadonlyArray<BankCompensationCode> = [];
 
 export const BANK_ACCOUNT_MASKS: Partial<Record<BankCompensationCode, string>> = {
   1: '99999999-9',

--- a/src/masks/masks.ts
+++ b/src/masks/masks.ts
@@ -30,19 +30,23 @@ export const PERCENTAGE_MASK_DEFAULTS: CurrencyMaskOptions = {
   zeroCents: false,
 };
 
-export const BANK_BRANCH_MASKS: Partial<Record<BankCompensationCode, string>> = {
-  341: '99999-9',
-};
+// Toda agência bancária é informada com 4 dígitos no frontend. Quando o banco
+// exige dígito verificador na agência (BB, Banrisul, Bradesco, Arbi), o DV é
+// calculado/validado pelo backend a partir dos 4 dígitos — não pelo input.
+// Por isso não há override por banco aqui: todos usam DEFAULT_BANK_BRANCH_MASK.
+export const BANK_BRANCH_MASKS: Partial<Record<BankCompensationCode, string>> = {};
 
 export const DEFAULT_BANK_BRANCH_MASK = '9999';
 
-export const ALPHANUMERIC_BANK_CODES: ReadonlyArray<BankCompensationCode> = ['1'];
+// Nenhum banco usa DV alfanumérico em conta: o backend valida DV apenas
+// numérico (/-\d/) e a UI orienta o usuário a trocar "X" por "0" (ex.: BB).
+export const ALPHANUMERIC_BANK_CODES: ReadonlyArray<BankCompensationCode> = [];
 
 export const BANK_ACCOUNT_MASKS: Partial<Record<BankCompensationCode, string>> = {
-  1: '99999999-S',
+  1: '99999999-9',
   33: '99999999-9',
   41: '999999999-9',
-  104: '999999999999-9',
+  104: '999999999-9',
   213: '9999999-9',
   237: '9999999-9',
   341: '99999-9',

--- a/tests/masks/maskBankAccount.spec.ts
+++ b/tests/masks/maskBankAccount.spec.ts
@@ -7,6 +7,10 @@ describe('maskBankAccount', () => {
     test('formata conta com dígito', () => {
       expect(maskBankAccount('123456789', '1')).toBe('12345678-9');
     });
+
+    test('DV é numérico: caractere não numérico é removido', () => {
+      expect(maskBankAccount('12345678X', '1')).toBe('12345678');
+    });
   });
 
   describe('Santander (33)', () => {
@@ -28,8 +32,8 @@ describe('maskBankAccount', () => {
   });
 
   describe('CEF (104)', () => {
-    test('formata conta longa com dígito', () => {
-      expect(maskBankAccount('1234567890123', '104')).toBe('123456789012-3');
+    test('formata conta com dígito (9 dígitos, sem operação)', () => {
+      expect(maskBankAccount('1234567890123', '104')).toBe('123456789-0');
     });
   });
 

--- a/tests/masks/maskBankAccount.spec.ts
+++ b/tests/masks/maskBankAccount.spec.ts
@@ -55,9 +55,9 @@ describe('maskBankAccount', () => {
     });
   });
 
-  describe('Banco Original (213)', () => {
+  describe('Arbi (213)', () => {
     test('formata conta com dígito', () => {
-      expect(maskBankAccount('12345678', '213')).toBe('1234567-8');
+      expect(maskBankAccount('12345678', '213')).toBe('12345-6');
     });
   });
 

--- a/tests/masks/maskBankBranch.spec.ts
+++ b/tests/masks/maskBankBranch.spec.ts
@@ -19,11 +19,11 @@ describe('maskBankBranch', () => {
     expect(maskBankBranch('1234', '33')).toBe('1234');
   });
 
-  test('agência Itaú (341) com dígito verificador', () => {
-    expect(maskBankBranch('123456', '341')).toBe('12345-6');
+  test('agência Itaú (341) tem 4 dígitos sem DV', () => {
+    expect(maskBankBranch('123456', '341')).toBe('1234');
   });
 
-  test('agência Itaú (341) parcial', () => {
+  test('agência Itaú (341) com 4 dígitos', () => {
     expect(maskBankBranch('1234', '341')).toBe('1234');
   });
 

--- a/tests/masks/maskComplete.spec.ts
+++ b/tests/masks/maskComplete.spec.ts
@@ -59,12 +59,12 @@ describe('maskComplete', () => {
     expect(maskComplete('12', 'bank_branch')).toBe(false);
   });
 
-  test('bank_branch completo com compensationCode Itaú (341)', () => {
-    expect(maskComplete('123456', 'bank_branch', '341')).toBe(true);
+  test('bank_branch completo com compensationCode Itaú (341) são 4 dígitos', () => {
+    expect(maskComplete('1234', 'bank_branch', '341')).toBe(true);
   });
 
   test('bank_branch incompleto com compensationCode Itaú (341)', () => {
-    expect(maskComplete('1234', 'bank_branch', '341')).toBe(false);
+    expect(maskComplete('12', 'bank_branch', '341')).toBe(false);
   });
 
   test('bank_account completo (noop 12+1 dígitos)', () => {
@@ -83,8 +83,8 @@ describe('maskComplete', () => {
     expect(maskComplete('123456789', 'bank_account', { compensationCode: '1' })).toBe(true);
   });
 
-  test('bank_account completo com DV alfanumérico BB (1)', () => {
-    expect(maskComplete('12345678X', 'bank_account', { compensationCode: '1' })).toBe(true);
+  test('bank_account BB (1) com DV não numérico não conta como completo', () => {
+    expect(maskComplete('12345678X', 'bank_account', { compensationCode: '1' })).toBe(false);
   });
 
   test('bank_account incompleto com compensationCode BB (1)', () => {

--- a/tests/masks/maskHintBankAccount.spec.ts
+++ b/tests/masks/maskHintBankAccount.spec.ts
@@ -16,7 +16,7 @@ describe('maskHintBankAccount', () => {
   });
 
   test('CEF (104)', () => {
-    expect(maskHintBankAccount('104')).toBe('000000000000-0');
+    expect(maskHintBankAccount('104')).toBe('000000000-0');
   });
 
   test('código desconhecido retorna placeholder default (noop)', () => {

--- a/tests/masks/maskValue.spec.ts
+++ b/tests/masks/maskValue.spec.ts
@@ -91,8 +91,8 @@ describe('maskValue', () => {
     test('strip de caracteres não numéricos', () => {
       expect(maskValue('12-34', 'bank_branch')).toBe('1234');
     });
-    test('com compensationCode Itaú (341) usa padrão 99999-9', () => {
-      expect(maskValue('123456', 'bank_branch', { compensationCode: '341' })).toBe('12345-6');
+    test('com compensationCode Itaú (341) usa 4 dígitos (sem DV)', () => {
+      expect(maskValue('123456', 'bank_branch', { compensationCode: '341' })).toBe('1234');
     });
     test('com compensationCode desconhecido usa padrão noop', () => {
       expect(maskValue('1234', 'bank_branch', { compensationCode: '999' })).toBe('1234');
@@ -109,11 +109,11 @@ describe('maskValue', () => {
     test('strip de separadores antes de aplicar', () => {
       expect(maskValue('123456789012-3', 'bank_account')).toBe('123456789012-3');
     });
-    test('com compensationCode BB (1) usa padrão 99999999-S', () => {
+    test('com compensationCode BB (1) usa padrão 99999999-9', () => {
       expect(maskValue('123456789', 'bank_account', { compensationCode: '1' })).toBe('12345678-9');
     });
-    test('com compensationCode BB (1) preserva DV alfanumérico', () => {
-      expect(maskValue('12345678X', 'bank_account', { compensationCode: '1' })).toBe('12345678-X');
+    test('com compensationCode BB (1) usa DV numérico (X é removido)', () => {
+      expect(maskValue('12345678X', 'bank_account', { compensationCode: '1' })).toBe('12345678');
     });
     test('com compensationCode Bradesco (237) usa padrão 9999999-9', () => {
       expect(maskValue('12345678', 'bank_account', { compensationCode: '237' })).toBe('1234567-8');


### PR DESCRIPTION
## Contexto

Correção da regressão introduzida no OR-145 (#35), reportada na PRD #37: ao transferir para o **Itaú (341)**, a máscara de **agência** ficava com 7 caracteres (`99999-9`) quando a agência do Itaú tem **4 dígitos sem DV**. O backend valida a agência do Itaú com `/^\d{4,4}$/`, então o valor mascarado (ex.: `09229-0`) era rejeitado com o erro **1503 – Agência inválida**.

## Causa raiz

O OR-145 **criou** o mapa `BANK_BRANCH_MASKS` (antes não existia máscara de agência) e definiu `341: '99999-9'` — que é exatamente a máscara de **conta** do Itaú (`BANK_ACCOUNT_MASKS[341]`). Foi um copy/paste da conta para a agência.

## Correções

- **Agência (todos os bancos):** remove o override do `341`; todos passam a usar `DEFAULT_BANK_BRANCH_MASK = '9999'` (4 dígitos). Validado contra o backend (`Bank::FORMATS` + `BankAccountValidator::Office::Generator`): para 33/341/104/399/745 a agência é `/^\d{4,4}$/`; para 1/237/41/213 o backend **calcula o DV** a partir dos 4 dígitos. **O Itaú era o único banco com máscara de agência errada.**
- **Conta Caixa (104):** `999999999999-9` (12) → `999999999-9` (9 dígitos).
- **Conta BB (1):** DV alfanumérico (`99999999-S`) → numérico (`99999999-9`), e `ALPHANUMERIC_BANK_CODES = []`.
- **Conta Arbi (213):** `9999999-9` (7) → `99999-9` (5 dígitos), alinhado ao legado.

## Paridade com o legado (PR #63 do mfe-payment-transfer)

Após estas correções, as **máscaras de banco do `@useblu/utils` ficam idênticas ao `src/utils/masks.js` legado** que o [mfe-payment-transfer#63](https://github.com/Pagnet/mfe-payment-transfer/pull/63) removeu — agência (`9999` para todos) e conta (todos os bancos) batem 1:1. As diferenças remanescentes são apenas em máscaras não-bancárias e **intencionais** (CNPJ alfanumérico, `phone_idd`).

## Testes

- Atualizados os testes que codificavam o comportamento incorreto (agência Itaú; conta Caixa 12 díg.; DV alfanumérico BB; conta Arbi 7 díg.).
- ✅ `yarn jest`: 147/147 passam · ✅ `yarn build` limpo.

## Rollout (após publicar 1.2.3)

> ⚠️ Em runtime, o `mfe-payment-transfer` consome `maskBankBranch` via `core/blu-utils`, **exposto pelo `mfe-core`** (`export * from '@useblu/utils'`). Corrigir produção exige:
> 1. publicar `@useblu/utils@1.2.3` (este PR, ao mergear no `master`);
> 2. bumpar `@useblu/utils → ^1.2.3` no **`mfe-core`** + regenerar `yarn.lock` + **redeploy** (passo que efetivamente corrige a agência em produção);
> 3. bumpar `@useblu/utils → ^1.2.3` no `mfe-payment-transfer` + regenerar `yarn.lock`.
>
> Ordem de deploy: `blu-utils` (publish) → `mfe-core` (redeploy) → `mfe-payment-transfer`.

Refs #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)