### PR TITLE
feat: add stripCpfCnpj (alphanumeric-safe CPF/CNPJ sanitizer)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { default as normalizeSocialNumber } from './normalizers/normalizeSocialN
 // utils
 export { default as maskString } from './utils/maskString';
 export { default as stripNumbers } from './utils/stripNumbers';
+export { default as stripCpfCnpj } from './utils/stripCpfCnpj';
 export { default as getStates } from './utils/getStates';
 export { default as snakeToCamel } from './utils/snakeToCamel';
 export { default as camelToSnake } from './utils/camelToSnake';

--- a/src/utils/stripCpfCnpj.ts
+++ b/src/utils/stripCpfCnpj.ts
@@ -1,0 +1,25 @@
+import { stripAlphanumeric } from '../masks/strip';
+
+/**
+ * Sanitiza um CPF/CNPJ removendo os separadores da máscara (qualquer caractere
+ * não-alfanumérico: `.`, `/`, `-`, espaços) e normalizando para upper-case,
+ * **preservando as letras** do CNPJ alfanumérico (Receita Federal —
+ * Nota Técnica NT 49/2024, vigente a partir de 2026).
+ *
+ * Use no lugar de `stripNumbers` / `value.replace(/\D/g, '')` em qualquer fluxo
+ * de CNPJ (validação, envio, lookup, navegação): essas abordagens descartam as
+ * letras A–Z e transformam um CNPJ alfanumérico válido em um identificador
+ * inválido.
+ *
+ * É o inverso de {@link normalizeCpfOrCnpj} (que aplica a máscara visual).
+ *
+ * @example
+ * stripCpfCnpj('824.007.050-70');     // '82400705070'  (CPF)
+ * stripCpfCnpj('12.345.678/0001-95'); // '12345678000195' (CNPJ numérico)
+ * stripCpfCnpj('AB.345.678/XY01-74'); // 'AB345678XY0174' (CNPJ alfanumérico)
+ * stripCpfCnpj('ab.345.678/xy01-74'); // 'AB345678XY0174' (normaliza upper-case)
+ * stripCpfCnpj(undefined);            // ''
+ */
+export default function stripCpfCnpj(value?: string): string {
+  return stripAlphanumeric(value ?? '');
+}

--- a/tests/stripCpfCnpj.spec.ts
+++ b/tests/stripCpfCnpj.spec.ts
@@ -1,0 +1,32 @@
+import 'jest';
+
+import { stripCpfCnpj } from '../src';
+
+describe('stripCpfCnpj', () => {
+  test('CPF mascarado → apenas dígitos', () => {
+    expect(stripCpfCnpj('824.007.050-70')).toBe('82400705070');
+  });
+
+  test('CNPJ numérico mascarado → apenas dígitos', () => {
+    expect(stripCpfCnpj('12.345.678/0001-95')).toBe('12345678000195');
+  });
+
+  // RFB NT 49/2024 — as letras fazem parte do identificador e não podem ser
+  // descartadas (o que aconteceria com stripNumbers / /\D/g).
+  test('CNPJ alfanumérico preserva as letras', () => {
+    expect(stripCpfCnpj('AB.345.678/XY01-74')).toBe('AB345678XY0174');
+  });
+
+  test('CNPJ alfanumérico minúsculo é normalizado para upper-case', () => {
+    expect(stripCpfCnpj('ab.345.678/xy01-74')).toBe('AB345678XY0174');
+  });
+
+  test('valor já sem máscara é idempotente', () => {
+    expect(stripCpfCnpj('AB345678XY0174')).toBe('AB345678XY0174');
+  });
+
+  test('undefined / vazio → string vazia', () => {
+    expect(stripCpfCnpj(undefined)).toBe('');
+    expect(stripCpfCnpj('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Adiciona um export público **`stripCpfCnpj`** — o sanitizador de CPF/CNPJ que estava faltando para o ecossistema lidar com **CNPJ alfanumérico** (Receita Federal — NT 49/2024, vigente a partir de 2026).

```ts
import { stripCpfCnpj } from '@useblu/utils';

stripCpfCnpj('12.345.678/0001-95'); // '12345678000195'  (CNPJ numérico)
stripCpfCnpj('AB.345.678/XY01-74'); // 'AB345678XY0174'  (CNPJ alfanumérico — letras preservadas)
stripCpfCnpj('ab.345.678/xy01-74'); // 'AB345678XY0174'  (normaliza upper-case)
```

Remove só os separadores da máscara (qualquer não-alfanumérico) e normaliza para upper-case, **preservando as letras** do CNPJ alfanumérico. É o **inverso** de `normalizeCpfOrCnpj` (que aplica a máscara).

## Por quê

Hoje os MFEs limpam CNPJ com `stripNumbers` ou `value.replace(/\D/g, '')` — ambos **descartam as letras A–Z** e transformam um CNPJ alfanumérico válido em inválido (`AB.345.678/XY01-74` → `3456780174`). O bug aparece como "CNPJ inválido"/"cliente não encontrado" para novos clientes a partir de 2026.

Não havia um *strip* alfanumérico-safe público na lib:
- `stripNumbers` → destrutivo (`/\D/g`)
- `normalizeCpfOrCnpj` → aplica máscara (o **inverso** de um strip)

Por isso vários MFEs criaram helpers locais `stripCnpj`/`stripCpfCnpj` duplicados (mfe-signup, mfe-bill, mfe-charge-management, mfe-payment-transfer, mfe-suppliers-lighthouse, mfe-pix, mfe-home). Este export centraliza a regra num **único ponto de atualização**, conforme `stack/alphanumeric-cnpj-stripping.md` (§2 — helper central), e permite remover os helpers locais.

## Implementação

- `src/utils/stripCpfCnpj.ts` — delega ao `stripAlphanumeric` interno (`src/masks/strip.ts`), que já é usado e testado por `maskValue`, `maskComplete`, `normalizeCpfOrCnpj` e `formatCnpj`. Zero lógica nova/duplicada.
- `src/index.ts` — novo export na seção `// utils`.
- `tests/stripCpfCnpj.spec.ts` — CPF, CNPJ numérico, alfanumérico (maiúsc./minúsc.), idempotência e `undefined`/vazio.

## Test plan

- [x] `yarn test` → **24 suites / 153 testes** (inclui os 6 novos), tudo verde
- [x] `yarn build` (`tsc --declaration`) → compila; export confirmado em `lib/` (`stripCpfCnpj('AB.345.678/XY01-74')` → `AB345678XY0174`)

## Próximos passos (follow-up)

1. PR de **bump de versão** (convenção do repo: bump em PR separado, ex. #34/#36) → publica a nova versão no npm.
2. Por MFE: bump do `@useblu/utils` + trocar o helper local por `import { stripCpfCnpj } from 'core/blu-utils'` + deletar o arquivo local. (Depende de 1 estar publicado — caso contrário recriaríamos o erro `is not a function` em CI.)

## Referências
- `stack/alphanumeric-cnpj-stripping.md`
- Receita Federal — NT 49/2024 (CNPJ alfanumérico)

🤖 Generated with [Claude Code](https://claude.com/claude-code)